### PR TITLE
update org.example:upstream to 0.0.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.example</groupId>
 		<artifactId>upstream</artifactId>
-		<version>0.0.28</version>
+		<version>0.0.29</version>
 		<!--
 		this is nonsense but allows us to test
 		<groupId>org.springframework.boot</groupId>
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>org.example</groupId>
 			<artifactId>upstream</artifactId>
-			<version>0.0.28</version>
+			<version>0.0.29</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.example:upstream` to: `0.0.29`